### PR TITLE
Enable markup placement while the effect is active

### DIFF
--- a/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
+++ b/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
@@ -506,3 +506,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     outputModel.GetDisplayNode().SliceIntersectionVisibilityOn()
 
     outputModel.Modified()
+
+  def interactionNodeModified(self, interactionNode):
+    # Override default behavior: keep the effect active if markup placement mode is activated
+    pass


### PR DESCRIPTION
Default behavior in Slicer core was changed to deactivate the active effect if user activates fiducial placement mode.
This commit changes this default behavior so that fiducial placement within the effect is allowed.